### PR TITLE
Patch: Hide the footer in reader view

### DIFF
--- a/patches/hidefooter.go
+++ b/patches/hidefooter.go
@@ -1,0 +1,43 @@
+// # Hide reader footer bar
+//
+// Adds a preference to hide the bottom chapter/footer bar in the reader.
+// When enabled, tapping to show chrome will not show the footer bar.
+package patches
+
+import (
+	. "github.com/pgaskin/lithiumpatch/patches/patchdef"
+)
+
+func init() {
+	Register("hidefooter",
+		// Add toggle in Settings → Advanced
+		PatchFile("res/xml/preferences.xml",
+			ReplaceStringAppend(
+				"\n"+`    <PreferenceCategory android:title="@string/pref_category_advanced">`,
+				"\n"+`        <SwitchPreferenceCompat android:title="Hide footer bar (reader)" android:key="hide_reader_footer" android:defaultValue="false" />`,
+			),
+		),
+
+		// In ReaderActivity#setChromeVisible(boolean), override only the nav bar behavior
+		// so the toolbar still follows chrome visibility, but the footer bar stays hidden
+		// if the preference is enabled.
+		PatchFile("smali/com/faultexception/reader/ReaderActivity.smali",
+			InMethod("setChromeVisible(Z)V",
+				// increase locals to have spare temp registers v6,v7,v8
+				ReplaceString(".locals 6", ".locals 10"),
+				ReplaceStringPrepend(
+					"    if-eqz p1, :cond_3\n",
+					"    # lithiumpatch: hide footer bar if user enabled setting (only affects nav bar)\n"+
+						"    const/4 v8, 0x0\n"+
+						"    iget-object v7, p0, Lcom/faultexception/reader/ReaderActivity;->mPrefs:Landroid/content/SharedPreferences;\n"+
+						"    const-string v6, \"hide_reader_footer\"\n"+
+						"    invoke-interface {v7, v6, v8}, Landroid/content/SharedPreferences;->getBoolean(Ljava/lang/String;Z)Z\n"+
+						"    move-result v8\n"+
+						"    if-eqz v8, :lith_patch_hf_cont\n"+
+						"    const/4 p1, 0x0\n"+
+						"    :lith_patch_hf_cont\n",
+				),
+			),
+		),
+	)
+}

--- a/patches/hidefooter.go
+++ b/patches/hidefooter.go
@@ -25,17 +25,31 @@ func init() {
 			InMethod("setChromeVisible(Z)V",
 				// increase locals to have spare temp registers v6,v7,v8
 				ReplaceString(".locals 6", ".locals 10"),
+				// Force nav bar translationY path to hidden on show when enabled
 				ReplaceStringPrepend(
 					"    if-eqz p1, :cond_3\n",
-					"    # lithiumpatch: hide footer bar if user enabled setting (only affects nav bar)\n"+
+					"    # lithiumpatch: hide footer bar on show when enabled (translationY)\n"+
 						"    const/4 v8, 0x0\n"+
 						"    iget-object v7, p0, Lcom/faultexception/reader/ReaderActivity;->mPrefs:Landroid/content/SharedPreferences;\n"+
 						"    const-string v6, \"hide_reader_footer\"\n"+
 						"    invoke-interface {v7, v6, v8}, Landroid/content/SharedPreferences;->getBoolean(Ljava/lang/String;Z)Z\n"+
 						"    move-result v8\n"+
-						"    if-eqz v8, :lith_patch_hf_cont\n"+
-						"    const/4 p1, 0x0\n"+
-						"    :lith_patch_hf_cont\n",
+						"    if-eqz v8, :lith_patch_hf_tyalive\n"+
+						"    goto :cond_3\n"+
+						"    :lith_patch_hf_tyalive\n",
+				),
+				// Force nav bar listener choice to invisibleAfter on show when enabled
+				ReplaceStringPrepend(
+					"    if-eqz p1, :cond_4\n",
+					"    # lithiumpatch: hide footer bar on show when enabled (listener)\n"+
+						"    const/4 v8, 0x0\n"+
+						"    iget-object v7, p0, Lcom/faultexception/reader/ReaderActivity;->mPrefs:Landroid/content/SharedPreferences;\n"+
+						"    const-string v6, \"hide_reader_footer\"\n"+
+						"    invoke-interface {v7, v6, v8}, Landroid/content/SharedPreferences;->getBoolean(Ljava/lang/String;Z)Z\n"+
+						"    move-result v8\n"+
+						"    if-eqz v8, :lith_patch_hf_lalive\n"+
+						"    goto :cond_4\n"+
+						"    :lith_patch_hf_lalive\n",
 				),
 			),
 		),

--- a/patches/hidefooterslider.go
+++ b/patches/hidefooterslider.go
@@ -1,12 +1,13 @@
+// # Hide footer slider
+//
+// Optionally hide the reading view footer slider to prevent accidental touches.
 package patches
 
-import (
-	. "github.com/pgaskin/lithiumpatch/patches/patchdef"
-)
+import . "github.com/pgaskin/lithiumpatch/patches/patchdef"
 
 func init() {
-	Register("hidefooter",
-		// Add toggle in Settings → Advanced
+	Register("hidefooterslider",
+		// add toggle in settings
 		PatchFile("res/xml/preferences.xml",
 			ReplaceStringAppend(
 				"\n"+`    <PreferenceCategory android:title="@string/pref_category_advanced">`,
@@ -14,11 +15,13 @@ func init() {
 			),
 		),
 
-		// Hide only the page slider when enabled. Do this once on activity start.
+		// hide only the page slider when enabled
 		PatchFile("smali/com/faultexception/reader/ReaderActivity.smali",
-			// Add helper method before onCreate
+			// add helper method before onCreate
 			ReplaceStringPrepend(
-				"\n"+`.method protected onCreate(Landroid/os/Bundle;)V`,
+				FixIndent("\n"+`
+				.method protected onCreate(Landroid/os/Bundle;)V
+				`),
 				FixIndent("\n"+`
                 .method private applyHideFooterSlider()V
                     .locals 3
@@ -40,11 +43,10 @@ func init() {
                 .end method
                 `),
 			),
-			// Call helper after SeekBar listener is set (robust minimal anchor)
+			// call helper after SeekBar listener is set (robust minimal anchor)
 			InMethod("onCreate(Landroid/os/Bundle;)V",
 				ReplaceStringAppend(
 					FixIndent("\n"+`
-						.line 373
 						invoke-virtual {v2, v0}, Landroid/widget/SeekBar;->setOnSeekBarChangeListener(Landroid/widget/SeekBar$OnSeekBarChangeListener;)V
 					`),
 					FixIndent("\n"+`
@@ -52,11 +54,12 @@ func init() {
 					`),
 				),
 			),
-
-			// Also apply on resume so changes from Settings take effect immediately
+			// also apply on resume so changes from settings take effect immediately
 			InMethod("onResume()V",
 				ReplaceStringAppend(
-					"\n"+`    invoke-super {p0}, Lcom/faultexception/reader/BaseActivity;->onResume()V`,
+					FixIndent("\n"+`
+						invoke-super {p0}, Lcom/faultexception/reader/BaseActivity;->onResume()V
+					`),
 					FixIndent("\n"+`
                         invoke-direct {p0}, Lcom/faultexception/reader/ReaderActivity;->applyHideFooterSlider()V
                     `),


### PR DESCRIPTION
Sometimes when im reading a book, and trying to use android gestures (swipe up to go home) the navbar to skip pages/chapters shows up and i fat finger that losing the page i was reading on.

This patch adds a toggle to disable the whole footer bar in reading view.